### PR TITLE
Неработающий tcp сокет, не верная типизация

### DIFF
--- a/src/pymax/payloads.py
+++ b/src/pymax/payloads.py
@@ -1,4 +1,4 @@
-from typing import Any, Final, Literal
+from typing import Any, Literal
 
 from pydantic import AliasChoices, BaseModel, Field
 
@@ -30,7 +30,7 @@ class CamelModel(BaseModel):
 
 
 class BaseWebSocketMessage(BaseModel):
-    ver: Final[int] = 11
+    ver: Literal[10, 11] = 11
     cmd: int
     seq: int
     opcode: int
@@ -195,14 +195,14 @@ class ChangeGroupProfilePayload(CamelModel):
 
 
 class GetGroupMembersPayload(CamelModel):
-    type: Final[str] = "MEMBER"
+    type: Literal["MEMBER"] = "MEMBER"
     marker: int
     chat_id: int
     count: int
 
 
 class SearchGroupMembersPayload(CamelModel):
-    type: Final[str] = "MEMBER"
+    type: Literal["MEMBER"] = "MEMBER"
     query: str
     chat_id: int
 


### PR DESCRIPTION
## Описание
Кратко, что делает этот PR. Например, добавляет новый метод, исправляет баг, улучшает документацию.

## Тип изменений
- [x] Исправление бага
- [ ] Новая функциональность
- [ ] Улучшение документации
- [ ] Рефакторинг

## Связанные задачи / Issue
Ссылка на issue, если есть: #

## Тестирование
Покажите пример кода, который проверяет изменения:

```python
import asyncio
from pymax.core import SocketMaxClient
import logging

log =logging.getLogger(f"{__name__}")
log.setLevel(logging.DEBUG)

phone = "+79201233211"
client = SocketMaxClient(phone=phone, work_dir="cache",
                   logger=log)


async def main() -> None:
    await client.start()
    await client.close()

if __name__ == "__main__":
    asyncio.run(main())
```

до предлагаемых изменений это код будет выкидывать ошибку подключения

## Почему так
Final не дружит с pydantic. При попытке присвоения дефолтного значения оно будет проигнорировано.
подробности [тык раз](https://github.com/pydantic/pydantic/issues/10474#issuecomment-2478666651) [тык2](https://github.com/pydantic/pydantic/issues/6253)
Сейчас все запросы webSocet and tcpSocket уходят без поля ver. 
Вебсокет это прощал😁 tcp более требовательный.


## Оффтоп

Есть гипотеза что основной интерфейс у них tcp все же 
А веб реализован отдельным сервисом прокси который кушает http немного обогащает его всяким флагами, фильтрует  и выкидывает в тот же tcp.

Таким образом у них помечаются веб сессии как короткоживущие с ограниченными привилегиями. 
И версия протокола там забита хардом что позволяет её пропустить на вебсокете.